### PR TITLE
Use 'utf-8' as default/fallback encoding.

### DIFF
--- a/changes/bug-4427_default-encoding-to-utf8
+++ b/changes/bug-4427_default-encoding-to-utf8
@@ -1,0 +1,2 @@
+  o Default encoding to 'utf-8' in case of system encodings not set. Closes
+    #4427.

--- a/src/leap/keymanager/openpgp.py
+++ b/src/leap/keymanager/openpgp.py
@@ -21,12 +21,14 @@ Infrastructure for using OpenPGP keys in Key Manager.
 """
 
 
+import locale
 import logging
 import os
 import re
 import shutil
+import sys
 import tempfile
-import locale
+
 from contextlib import closing
 
 from gnupg import GPG
@@ -516,6 +518,10 @@ class OpenPGPScheme(EncryptionScheme):
             # https://github.com/isislovecruft/python-gnupg/\
             #   blob/master/gnupg/_meta.py#L121
             encoding = locale.getpreferredencoding()
+            if encoding is None:
+                encoding = sys.stdin.encoding
+            if encoding is None:
+                encoding = 'utf-8'
             return result.data.decode(encoding, 'replace')
 
     def is_encrypted(self, data):


### PR DESCRIPTION
- Also reorder stdlib imports alphabetically :)

[Closes #4427]
