### PR TITLE
Do not memoize get_key, but a separate method.

### DIFF
--- a/src/leap/keymanager/__init__.py
+++ b/src/leap/keymanager/__init__.py
@@ -252,6 +252,12 @@ class KeyManager(object):
         signal(proto.KEYMANAGER_DONE_UPLOADING_KEYS, self._address)
 
     @memoized_method
+    def get_key_from_cache(self, *args, **kwargs):
+        """
+        Public interface to `get_key`, that is memoized.
+        """
+        return self.get_key(*args, **kwargs)
+
     def get_key(self, address, ktype, private=False, fetch_remote=True):
         """
         Return a key of type C{ktype} bound to C{address}.


### PR DESCRIPTION
In this way we can choose which calls to get from cache
and we do not mess with the call from send_key
