### PR TITLE
Fix call to python-gnupg verify_file() method (#6022).

### DIFF
--- a/changes/bug_6022_fix-call-to-verify-file
+++ b/changes/bug_6022_fix-call-to-verify-file
@@ -1,0 +1,1 @@
+  o Fix call to python-gnupg's verify_file() method (#6022).


### PR DESCRIPTION
It seems to me that the previous change made to the `verify()` method was misguided by a bug in python-gnupg: https://github.com/isislovecruft/python-gnupg/pull/60
