### PR TITLE
Feature/6210 key newer

### DIFF
--- a/src/leap/keymanager/keys.py
+++ b/src/leap/keymanager/keys.py
@@ -30,6 +30,7 @@ import re
 
 
 from abc import ABCMeta, abstractmethod
+from datetime import datetime
 from leap.common.check import leap_assert
 
 from leap.keymanager.validation import ValidationLevel, toValidationLevel
@@ -118,6 +119,10 @@ def build_key_from_dict(kClass, address, kdict):
                      (kdict[KEY_VALIDATION_KEY], kdict[KEY_ID_KEY]))
         validation = ValidationLevel.Weak_Chain
 
+    expiry_date = None
+    if kdict[KEY_EXPIRY_DATE_KEY]:
+        expiry_date = datetime.fromtimestamp(int(kdict[KEY_EXPIRY_DATE_KEY]))
+
     return kClass(
         address,
         key_id=kdict[KEY_ID_KEY],
@@ -125,7 +130,7 @@ def build_key_from_dict(kClass, address, kdict):
         key_data=kdict[KEY_DATA_KEY],
         private=kdict[KEY_PRIVATE_KEY],
         length=kdict[KEY_LENGTH_KEY],
-        expiry_date=kdict[KEY_EXPIRY_DATE_KEY],
+        expiry_date=expiry_date,
         first_seen_at=kdict[KEY_FIRST_SEEN_AT_KEY],
         last_audited_at=kdict[KEY_LAST_AUDITED_AT_KEY],
         validation=validation,
@@ -167,6 +172,10 @@ class EncryptionKey(object):
         :return: The JSON string describing this key.
         :rtype: str
         """
+        expiry_str = ""
+        if self.expiry_date is not None:
+            expiry_str = self.expiry_date.strftime("%s")
+
         return json.dumps({
             KEY_ADDRESS_KEY: self.address,
             KEY_TYPE_KEY: str(self.__class__),
@@ -175,7 +184,7 @@ class EncryptionKey(object):
             KEY_DATA_KEY: self.key_data,
             KEY_PRIVATE_KEY: self.private,
             KEY_LENGTH_KEY: self.length,
-            KEY_EXPIRY_DATE_KEY: self.expiry_date,
+            KEY_EXPIRY_DATE_KEY: expiry_str,
             KEY_VALIDATION_KEY: str(self.validation),
             KEY_FIRST_SEEN_AT_KEY: self.first_seen_at,
             KEY_LAST_AUDITED_AT_KEY: self.last_audited_at,

--- a/src/leap/keymanager/openpgp.py
+++ b/src/leap/keymanager/openpgp.py
@@ -25,6 +25,7 @@ import tempfile
 import io
 
 
+from datetime import datetime
 from gnupg import GPG
 from gnupg.gnupg import GPGUtilities
 
@@ -178,6 +179,10 @@ def _build_key_from_gpg(address, key, key_data):
     :return: An instance of the key.
     :rtype: OpenPGPKey
     """
+    expiry_date = None
+    if key['expires']:
+        expiry_date = datetime.fromtimestamp(int(key['expires']))
+
     return OpenPGPKey(
         address,
         key_id=key['keyid'],
@@ -185,7 +190,7 @@ def _build_key_from_gpg(address, key, key_data):
         key_data=key_data,
         private=True if key['type'] == 'sec' else False,
         length=key['length'],
-        expiry_date=key['expires'],
+        expiry_date=expiry_date,
         validation=ValidationLevel.Weak_Chain,
     )
 

--- a/src/leap/keymanager/tests/test_keymanager.py
+++ b/src/leap/keymanager/tests/test_keymanager.py
@@ -81,7 +81,7 @@ class KeyManagerUtilTestCase(BaseLeapTest):
             'key_data': 'key_data',
             'private': 'private',
             'length': 'length',
-            'expiry_date': 'expiry_date',
+            'expiry_date': '',
             'first_seen_at': 'first_seen_at',
             'last_audited_at': 'last_audited_at',
             'validation': str(ValidationLevel.Weak_Chain),
@@ -106,7 +106,7 @@ class KeyManagerUtilTestCase(BaseLeapTest):
             kdict['length'], key.length,
             'Wrong data in key.')
         self.assertEqual(
-            kdict['expiry_date'], key.expiry_date,
+            None, key.expiry_date,
             'Wrong data in key.')
         self.assertEqual(
             kdict['first_seen_at'], key.first_seen_at,

--- a/src/leap/keymanager/tests/test_validation.py
+++ b/src/leap/keymanager/tests/test_validation.py
@@ -18,6 +18,8 @@
 Tests for the Validation Levels
 """
 
+from datetime import datetime
+
 from leap.keymanager.openpgp import OpenPGPKey
 from leap.keymanager.errors import (
     KeyNotValidUpgrade
@@ -152,8 +154,7 @@ Osuse7+NkyUHgMXMVW7cz+nU7iO+ht2rkBtv+Z5LGlzgHTeFjKci
 -----END PGP PUBLIC KEY BLOCK-----
 """
 # updated expiration date
-# Tue 24 Oct 2034 05:13:00 PM BST
-EXPIRED_KEY_NEW_EXPIRY_DATE = "2045319180"
+EXPIRED_KEY_NEW_EXPIRY_DATE = datetime.fromtimestamp(2045319180)
 EXPIRED_KEY_UPDATED = """
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1.4.12 (GNU/Linux)

--- a/src/leap/keymanager/validation.py
+++ b/src/leap/keymanager/validation.py
@@ -80,11 +80,10 @@ def can_upgrade(new_key, old_key):
         return True
 
     # Expired key and higher validation level
-    if old_key.expiry_date:
-        old_expiry_date = datetime.fromtimestamp(int(old_key.expiry_date))
-        if (old_expiry_date < datetime.now() and
-                new_key.validation >= old_key.validation):
-            return True
+    if (old_key.expiry_date is not None and
+            old_key.expiry_date < datetime.now() and
+            new_key.validation >= old_key.validation):
+        return True
 
     # No expiration date and higher validation level
     elif new_key.validation >= old_key.validation:


### PR DESCRIPTION
Use gnupg to merge keys if it's an update of an existing key. This is needed to prevent roll back attacks where the attacker push us to accept a key with an old expiration date that could be use to push an untrusted key when after it's expiration.
