### PR TITLE
[feat] set fetched keys as Weak Chain if they are not from the same domain

### DIFF
--- a/changes/feature-6815_nicknym_validation_level
+++ b/changes/feature-6815_nicknym_validation_level
@@ -1,0 +1,1 @@
+-  fetched keys from other domain than its provider are set as 'Weak Chain' validation level (Closes: #6815)


### PR DESCRIPTION
Nicknym server is authoritative for it's own domain, but for others it might
retrieve keys from key servers. On keys from the same domain we set the
validation level to 'Provider Trust'. For other domains in the email
address we set it to 'Weak Chain' as we don't have info about it's source.

Resolves: #6815
Related: #6718
Releases: 0.4.0