### PR TITLE
[doc] added the right link the validation levels documentation

### DIFF
--- a/src/leap/keymanager/validation.py
+++ b/src/leap/keymanager/validation.py
@@ -19,7 +19,7 @@
 Validation levels implementation for key managment.
 
 See:
-    https://lists.riseup.net/www/arc/leap-discuss/2014-09/msg00000.html
+    https://leap.se/en/docs/design/transitional-key-validation
 """
 
 


### PR DESCRIPTION
The mailing list was linked, but now there is a proper documentation
page.

- Releases: 0.4.0