### PR TITLE
[feat] adapt to new events api on common

### DIFF
--- a/changes/VERSION_COMPAT
+++ b/changes/VERSION_COMPAT
@@ -8,4 +8,4 @@
 #
 # BEGIN DEPENDENCY LIST -------------------------
 # leap.foo.bar>=x.y.z
-leap.common>=0.3.10
+leap.common>=0.4

--- a/changes/feature_adapt-to-new-events-on-common
+++ b/changes/feature_adapt-to-new-events-on-common
@@ -1,0 +1,1 @@
+- Adapt to new events api on leap.common. Related to #5359.


### PR DESCRIPTION
**DO NOT MERGE YET**

These are the changes needed to use the new events api on `leap.common` waiting to be merged on https://github.com/leapcode/leap_pycommon/pull/95

- Related: #6359