### PR TITLE
[pkg] avoid choking on latest gnupg version

### DIFF
--- a/src/leap/keymanager/__init__.py
+++ b/src/leap/keymanager/__init__.py
@@ -24,13 +24,20 @@ try:
     from gnupg.gnupg import GPGUtilities
     assert(GPGUtilities)  # pyflakes happy
     from gnupg import __version__ as _gnupg_version
+    if '-' in _gnupg_version:
+        # avoid Parsing it as LegacyVersion, get just
+        # the release numbers:
+        _gnupg_version = _gnupg_version.split('-')[0]
     from pkg_resources import parse_version
+    # We need to make sure that we're not colliding with the infamous
+    # python-gnupg
     assert(parse_version(_gnupg_version) >= parse_version('1.4.0'))
 
 except (ImportError, AssertionError):
     print "*******"
     print "Ooops! It looks like there is a conflict in the installed version "
     print "of gnupg."
+    print "GNUPG_VERSION:", _gnupg_version
     print
     print "Disclaimer: Ideally, we would need to work a patch and propose the "
     print "merge to upstream. But until then do: "


### PR DESCRIPTION
latest gnupg version (from pypi) was '2.0.2-py2.7.egg', which is parsed
as a LegacyVersion and therefore breaks the numeric comparison. this is
a workaround to allow the sanity check to continue, by comparing just
the numeric part of the version string.