### PR TITLE
[pkg] add soledad-client as a leap dependency for keymanager

### DIFF
--- a/pkg/requirements-leap.pip
+++ b/pkg/requirements-leap.pip
@@ -1,1 +1,2 @@
 leap.common>=0.4.0
+leap.soledad.client>=0.7.0

--- a/pkg/requirements-testing.pip
+++ b/pkg/requirements-testing.pip
@@ -1,3 +1,2 @@
 mock
-leap.soledad.client
 setuptools-trial


### PR DESCRIPTION
we were missing this dep, and was included as a testing dependency.