### PR TITLE
Fixed remaining pep8 warnings and added requirements-latest for CI

### DIFF
--- a/pkg/requirements-latest.pip
+++ b/pkg/requirements-latest.pip
@@ -1,0 +1,8 @@
+--index-url https://pypi.python.org/simple/
+
+--allow-external u1db  --allow-unverified u1db
+--allow-external dirspec  --allow-unverified dirspec
+-e 'git+https://github.com/pixelated-project/leap_pycommon.git@develop#egg=leap.common'
+-e 'git+https://github.com/pixelated-project/soledad.git@develop#egg=leap.soledad.common&subdirectory=common/'
+-e 'git+https://github.com/pixelated-project/soledad.git@develop#egg=leap.soledad.client&subdirectory=client/'
+-e .

--- a/src/leap/keymanager/__init__.py
+++ b/src/leap/keymanager/__init__.py
@@ -19,6 +19,7 @@ Key Manager is a Nicknym agent for LEAP client.
 """
 # let's do a little sanity check to see if we're using the wrong gnupg
 import sys
+from ._version import get_versions
 
 try:
     from gnupg.gnupg import GPGUtilities

--- a/src/leap/keymanager/_version.py
+++ b/src/leap/keymanager/_version.py
@@ -1,5 +1,3 @@
-
-IN_LONG_VERSION_PY = True
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (build by setup.py sdist) and build
@@ -10,12 +8,15 @@ IN_LONG_VERSION_PY = True
 # versioneer-0.7+ (https://github.com/warner/python-versioneer)
 
 # these strings will be replaced by git during git-archive
-git_refnames = "$Format:%d$"
-git_full = "$Format:%H$"
-
-
 import subprocess
 import sys
+import re
+import os.path
+
+IN_LONG_VERSION_PY = True
+
+git_refnames = "$Format:%d$"
+git_full = "$Format:%H$"
 
 
 def run_command(args, cwd=None, verbose=False):
@@ -36,10 +37,6 @@ def run_command(args, cwd=None, verbose=False):
             print("unable to run %s (error)" % args[0])
         return None
     return stdout
-
-
-import re
-import os.path
 
 
 def get_expanded_variables(versionfile_source):
@@ -86,7 +83,7 @@ def versions_from_expanded_variables(variables, tag_prefix, verbose=False):
         # "stabilization", as well as "HEAD" and "master".
         tags = set([r for r in refs if re.search(r'\d', r)])
         if verbose:
-            print("discarding '%s', no digits" % ",".join(refs-tags))
+            print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
         print("likely tags: %s" % ",".join(sorted(tags)))
     for ref in sorted(tags):

--- a/src/leap/keymanager/openpgp.py
+++ b/src/leap/keymanager/openpgp.py
@@ -114,8 +114,11 @@ class TempGPGWrapper(object):
         publkeys = filter(
             lambda pubkey: pubkey.key_id not in privids, publkeys)
 
-        listkeys = lambda: self._gpg.list_keys()
-        listsecretkeys = lambda: self._gpg.list_keys(secret=True)
+        def listkeys():
+            return self._gpg.list_keys()
+
+        def listsecretkeys():
+            return self._gpg.list_keys(secret=True)
 
         self._gpg = GPG(binary=self._gpgbinary,
                         homedir=tempfile.mkdtemp())

--- a/src/leap/keymanager/openpgp.py
+++ b/src/leap/keymanager/openpgp.py
@@ -111,14 +111,10 @@ class TempGPGWrapper(object):
         # and we want to count the keys afterwards.
 
         privids = map(lambda privkey: privkey.key_id, privkeys)
-        publkeys = filter(
-            lambda pubkey: pubkey.key_id not in privids, publkeys)
+        publkeys = filter(lambda pubkey: pubkey.key_id not in privids, publkeys)
 
-        def listkeys():
-            return self._gpg.list_keys()
-
-        def listsecretkeys():
-            return self._gpg.list_keys(secret=True)
+        listkeys = lambda: self._gpg.list_keys()
+        listsecretkeys = lambda: self._gpg.list_keys(secret=True)
 
         self._gpg = GPG(binary=self._gpgbinary,
                         homedir=tempfile.mkdtemp())

--- a/src/leap/keymanager/tests/test_validation.py
+++ b/src/leap/keymanager/tests/test_validation.py
@@ -18,6 +18,7 @@
 Tests for the Validation Levels
 """
 
+import unittest
 from datetime import datetime
 from twisted.internet.defer import inlineCallbacks
 


### PR DESCRIPTION
Keymanager is now running on the CI here:
https://snap-ci.com/pixelated-project/keymanager/branch/develop

Had to fix some of the leftover pep8 warnings and added a requirements-latest.pip to use the latest develop/HEAD automatically