### PR TITLE
[feat] add logging to fetch_key

### DIFF
--- a/src/leap/keymanager/__init__.py
+++ b/src/leap/keymanager/__init__.py
@@ -779,6 +779,7 @@ class KeyManager(object):
         """
         self._assert_supported_key_type(ktype)
 
+        logger.info("Fetch key for %s from %s" % (address, uri))
         res = self._get(uri)
         if not res.ok:
             return defer.fail(KeyNotFound(uri))


### PR DESCRIPTION
In case of failure of fetch_key will be useful to have some logging
telling us wich key is fetching.

- Related: #7410