### PR TITLE
[bug] catch request exceptions

### DIFF
--- a/changes/bug-7410_fetch_key
+++ b/changes/bug-7410_fetch_key
@@ -1,0 +1,1 @@
+- catch request exceptions on key fetching

--- a/src/leap/keymanager/__init__.py
+++ b/src/leap/keymanager/__init__.py
@@ -820,7 +820,11 @@ class KeyManager(object):
         self._assert_supported_key_type(ktype)
 
         logger.info("Fetch key for %s from %s" % (address, uri))
-        res = self._get_with_combined_ca_bundle(uri)
+        try:
+            res = self._get_with_combined_ca_bundle(uri)
+        except Exception as e:
+            logger.warning("There was a problem fetching key: %s" % (e,))
+            return defer.fail(KeyNotFound(uri))
         if not res.ok:
             return defer.fail(KeyNotFound(uri))
 


### PR DESCRIPTION
On fetch_key we were not catching the request exceptions, now they are
returned as failure in the deferred as it should.

- Related: #7410