### PR TITLE
[bug] don't repush a public key whith different address

### DIFF
--- a/changes/bug-address_mixup
+++ b/changes/bug-address_mixup
@@ -1,0 +1,1 @@
+- Don't repush a public key with different address


### PR DESCRIPTION
During decryption the signing public key was getting repush with a
different address as part of the verify usage flagging.