### PR TITLE
[bug] treat empty string ca_cert_path as None

### DIFF
--- a/src/leap/keymanager/__init__.py
+++ b/src/leap/keymanager/__init__.py
@@ -148,7 +148,7 @@ class KeyManager(object):
 
         if self._ca_cert_path == leap_ca_bundle:
             return self._ca_cert_path   # don't merge file with itself
-        elif self._ca_cert_path is None:
+        elif not self._ca_cert_path:
             return leap_ca_bundle
 
         # file is auto deleted when python process ends

--- a/src/leap/keymanager/tests/test_keymanager.py
+++ b/src/leap/keymanager/tests/test_keymanager.py
@@ -346,7 +346,18 @@ class KeyManagerKeyManagementTestCase(KeyManagerWithSoledadTestCase):
                                          verify=ca_bundle.where())
 
     @inlineCallbacks
-    def test_fetch_key_uses_default_ca_bundle_if_also_set_as_ca_cert(self):
+    def test_fetch_key_uses_ca_bundle_if_empty_string_specified(self):
+        ca_cert_path = ''
+        km = self._key_manager(ca_cert_path=ca_cert_path)
+        get_mock = self._mock_get_response(km, PUBLIC_KEY_OTHER)
+
+        yield km.fetch_key(ADDRESS_OTHER, REMOTE_KEY_URL, OpenPGPKey)
+
+        get_mock.assert_called_once_with(REMOTE_KEY_URL, data=None,
+                                         verify=ca_bundle.where())
+
+    @inlineCallbacks
+    def test_fetch_key_uses_default_ca_bundle_if_also_set_as_ca_cert_path(self):
         ca_cert_path = ca_bundle.where()
         km = self._key_manager(ca_cert_path=ca_cert_path)
         get_mock = self._mock_get_response(km, PUBLIC_KEY_OTHER)


### PR DESCRIPTION
Hey,

found a problem in my last PR, commit 9546348c36. Without this fix a lot of tests in leap_mail because they pass empty string for ca_cert_path.
## 

Fixup for 9546348c36. This problem only occurs in
test setups where '' is passed to ca_cert_path.
