### PR TITLE
[bug] keep combined file longer in scope

### DIFF
--- a/src/leap/keymanager/__init__.py
+++ b/src/leap/keymanager/__init__.py
@@ -22,7 +22,9 @@ import fileinput
 import os
 import sys
 import tempfile
+
 from leap.common import ca_bundle
+
 from ._version import get_versions
 
 try:
@@ -146,7 +148,8 @@ class KeyManager(object):
 
     def __del__(self):
         try:
-            created_tmp_combined_ca_bundle = self._combined_ca_bundle not in [ca_bundle.where(), self._ca_cert_path]
+            created_tmp_combined_ca_bundle = self._combined_ca_bundle not in \
+                [ca_bundle.where(), self._ca_cert_path]
             if created_tmp_combined_ca_bundle:
                 os.remove(self._combined_ca_bundle)
         except OSError:
@@ -164,7 +167,7 @@ class KeyManager(object):
         elif not self._ca_cert_path:
             return leap_ca_bundle
 
-        tmp_file = tempfile.NamedTemporaryFile(delete=False)  # delete when keymanager expires
+        tmp_file = tempfile.NamedTemporaryFile(delete=False)
 
         with open(tmp_file.name, 'w') as fout:
             fin = fileinput.input(files=(leap_ca_bundle, self._ca_cert_path))

--- a/src/leap/keymanager/__init__.py
+++ b/src/leap/keymanager/__init__.py
@@ -19,6 +19,7 @@ Key Manager is a Nicknym agent for LEAP client.
 """
 # let's do a little sanity check to see if we're using the wrong gnupg
 import fileinput
+import os
 import sys
 import tempfile
 from leap.common import ca_bundle
@@ -140,6 +141,18 @@ class KeyManager(object):
         self._combined_ca_bundle = self._create_combined_bundle_file()
 
     #
+    # destructor
+    #
+
+    def __del__(self):
+        try:
+            created_tmp_combined_ca_bundle = self._combined_ca_bundle not in [ca_bundle.where(), self._ca_cert_path]
+            if created_tmp_combined_ca_bundle:
+                os.remove(self._combined_ca_bundle)
+        except OSError:
+            pass
+
+    #
     # utilities
     #
 
@@ -151,8 +164,7 @@ class KeyManager(object):
         elif not self._ca_cert_path:
             return leap_ca_bundle
 
-        # file is auto deleted when python process ends
-        tmp_file = tempfile.NamedTemporaryFile(delete=True)
+        tmp_file = tempfile.NamedTemporaryFile(delete=False)  # delete when keymanager expires
 
         with open(tmp_file.name, 'w') as fout:
             fin = fileinput.input(files=(leap_ca_bundle, self._ca_cert_path))

--- a/src/leap/keymanager/tests/test_keymanager.py
+++ b/src/leap/keymanager/tests/test_keymanager.py
@@ -357,7 +357,7 @@ class KeyManagerKeyManagementTestCase(KeyManagerWithSoledadTestCase):
                                          verify=ca_bundle.where())
 
     @inlineCallbacks
-    def test_fetch_key_uses_default_ca_bundle_if_also_set_as_ca_cert_path(self):
+    def test_fetch_key_use_default_ca_bundle_if_set_as_ca_cert_path(self):
         ca_cert_path = ca_bundle.where()
         km = self._key_manager(ca_cert_path=ca_cert_path)
         get_mock = self._mock_get_response(km, PUBLIC_KEY_OTHER)
@@ -369,7 +369,8 @@ class KeyManagerKeyManagementTestCase(KeyManagerWithSoledadTestCase):
 
     @inlineCallbacks
     def test_fetch_uses_combined_ca_bundle_otherwise(self):
-        with tempfile.NamedTemporaryFile() as tmp_input, tempfile.NamedTemporaryFile(delete=False) as tmp_output:
+        with tempfile.NamedTemporaryFile() as tmp_input, \
+                tempfile.NamedTemporaryFile(delete=False) as tmp_output:
             ca_content = 'some\ncontent\n'
             ca_cert_path = tmp_input.name
             self._dump_to_file(ca_cert_path, ca_content)

--- a/src/leap/keymanager/tests/test_keymanager.py
+++ b/src/leap/keymanager/tests/test_keymanager.py
@@ -20,7 +20,7 @@
 Tests for the Key Manager.
 """
 
-
+from os import path
 from datetime import datetime
 import tempfile
 from leap.common import ca_bundle
@@ -369,8 +369,7 @@ class KeyManagerKeyManagementTestCase(KeyManagerWithSoledadTestCase):
 
     @inlineCallbacks
     def test_fetch_uses_combined_ca_bundle_otherwise(self):
-        with tempfile.NamedTemporaryFile() as tmp_input, \
-                tempfile.NamedTemporaryFile() as tmp_output:
+        with tempfile.NamedTemporaryFile() as tmp_input, tempfile.NamedTemporaryFile(delete=False) as tmp_output:
             ca_content = 'some\ncontent\n'
             ca_cert_path = tmp_input.name
             self._dump_to_file(ca_cert_path, ca_content)
@@ -389,6 +388,9 @@ class KeyManagerKeyManagementTestCase(KeyManagerWithSoledadTestCase):
                 # assert that files got appended
                 expected = self._slurp_file(ca_bundle.where()) + ca_content
                 self.assertEqual(expected, self._slurp_file(tmp_output.name))
+
+            del km  # force km out of scope
+            self.assertFalse(path.exists(tmp_output.name))
 
     def _dump_to_file(self, filename, content):
             with open(filename, 'w') as out:


### PR DESCRIPTION
Another fixup for 9546348c that should have been part of PR 87, but got lost during rebasing and preparing the PR. 

Problem is:
The combined bundle ca was not long enough in scope and was therefore deleted when it actually was used. Adopted test to check whether file is deleted.
