### PR TITLE
[feat] defer decrypt, gen_key and encrypt

### DIFF
--- a/changes/async_gpg
+++ b/changes/async_gpg
@@ -1,0 +1,1 @@
+-- Defer encrypt, decrypt and gen_key operations from gnupg to external threads, limited by cpu core amount.


### PR DESCRIPTION
This commit put those gnupg operations to be run on external threads
limited by the amount of cores present on user machine.
Some gnupg calls spawn processes and communicating to them is a
synchronous operation, so running outside of a reactor should improve
response time by avoiding reactor locking.