### PR TITLE
[bug] don't remove combined_bundle file on destructor

### DIFF
--- a/src/leap/keymanager/__init__.py
+++ b/src/leap/keymanager/__init__.py
@@ -131,19 +131,6 @@ class KeyManager(object):
         self.refresher = None
 
     #
-    # destructor
-    #
-
-    def __del__(self):
-        try:
-            created_tmp_combined_ca_bundle = self._combined_ca_bundle not in \
-                [ca_bundle.where(), self._ca_cert_path]
-            if created_tmp_combined_ca_bundle:
-                os.remove(self._combined_ca_bundle)
-        except OSError:
-            pass
-
-    #
     # utilities
     #
 

--- a/tests/test_keymanager.py
+++ b/tests/test_keymanager.py
@@ -20,7 +20,6 @@
 Tests for the Key Manager.
 """
 
-from os import path
 import json
 import urllib
 from datetime import datetime
@@ -495,9 +494,6 @@ class KeyManagerKeyManagementTestCase(KeyManagerWithSoledadTestCase):
                 # assert that files got appended
                 expected = self._slurp_file(ca_bundle.where()) + ca_content
                 self.assertEqual(expected, self._slurp_file(tmp_output.name))
-
-            del km  # force km out of scope
-            self.assertFalse(path.exists(tmp_output.name))
 
     def _dump_to_file(self, filename, content):
             with open(filename, 'w') as out:


### PR DESCRIPTION
After PR #116, it's possible to inject an existing combined_ca_bundle
to the keymanager initialisation. However, it won't work for multiple
users because the file is removed when the keymanager is destroyed.

Considering there's no sensitive data on the file and it's created
as a temp file, we don't need to handle its deletion.

We also adapted the test to not assert the deletion of the file.